### PR TITLE
Fix a couple of warnings in R CMD check

### DIFF
--- a/R/feather2calc_genoprob.R
+++ b/R/feather2calc_genoprob.R
@@ -5,7 +5,7 @@
 #'
 #' @param object Object of class \code{\link{feather_genoprob}}.
 #'
-#' @return An object of class \code{\link[qtlgeno]{calc_genoprob}}.
+#' @return An object of class \code{\link[qtl2geno]{calc_genoprob}}.
 #'
 #' @details
 #' The genotype probabilities are extracted from 1-2 feather databases. Each chromosome is extracted in turn.

--- a/R/feather2calc_genoprob.R
+++ b/R/feather2calc_genoprob.R
@@ -9,7 +9,7 @@
 #'
 #' @details
 #' The genotype probabilities are extracted from 1-2 feather databases. Each chromosome is extracted in turn.
-#' 
+#'
 #' @export
 #' @keywords utilities
 #'
@@ -20,11 +20,11 @@
 #' probs <- calc_genoprob(grav2, map, error_prob=0.002)
 #' fprobs <- feather_genoprob(probs, "my.feather")
 #' nprobs <- feather2calc_genoprob(fprobs)
-#' 
+#'
 feather2calc_genoprob <- function(object) {
   if(!inherits(object, "feather_genoprob"))
     stop("object must inherit class feather_genoprob")
-  
+
   attrs <- attributes(object)
 
   chr <- unclass(object)$chr
@@ -32,13 +32,13 @@ feather2calc_genoprob <- function(object) {
   names(result) <- chr
   for(chri in chr)
     result[[chri]] <- object[[chri]]
-  
+
   # Set up attributes.
   ignore <- match(c("names","class"), names(attrs))
   for(a in names(attrs)[-ignore])
     attr(result, a) <- attrs[[a]]
-  
+
   class(result) <- attrs$class[-1]
-  
+
   result
 }

--- a/R/feather_genoprob.R
+++ b/R/feather_genoprob.R
@@ -11,7 +11,7 @@
 #' @param verbose Show warning of feather creation if \code{TRUE} (default).
 #'
 #' @return A list containing the attributes of \code{genoprob}
-#' and the address for the created feather database. Access components with \code{\link{feather_genoprob_list}}.
+#' and the address for the created feather database.
 #' Components are:
 #' \itemize{
 #' \item \code{dim} - List of all dimensions of 3-D arrays.

--- a/man/feather2calc_genoprob.Rd
+++ b/man/feather2calc_genoprob.Rd
@@ -10,7 +10,7 @@ feather2calc_genoprob(object)
 \item{object}{Object of class \code{\link{feather_genoprob}}.}
 }
 \value{
-An object of class \code{\link[qtlgeno]{calc_genoprob}}.
+An object of class \code{\link[qtl2geno]{calc_genoprob}}.
 }
 \description{
 Uses package feather to convert R object created in R/qtl2geno for fast access.

--- a/man/feather_genoprob.Rd
+++ b/man/feather_genoprob.Rd
@@ -19,7 +19,7 @@ and \code{\link[qtl2geno]{calc_genoprob}}.}
 }
 \value{
 A list containing the attributes of \code{genoprob}
-and the address for the created feather database. Access components with \code{\link{feather_genoprob_list}}.
+and the address for the created feather database.
 Components are:
 \itemize{
 \item \code{dim} - List of all dimensions of 3-D arrays.


### PR DESCRIPTION
- one place with `\link[qtlgeno]{}`, which needed to be `\link[qtl2geno]{}`

- a link to `feather_genoprob_list`, which was later removed