### PR TITLE
Add test of qtl2::pull_genoprobpos()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ r_packages:
  - dplyr
 
 r_github_packages:
- - rqtl/qtl2
+ - kbroman/qtl2
 
 addons:
   apt:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: qtl2feather
-Version: 0.3-7
-Date: 2018-02-15
+Version: 0.3-8
+Date: 2018-03-09
 Title: Feather Database for R/qtl2 Genotype Probabilities
 Description: Functions to rbind, cbind and subset `calc_genoprob` objects.
 Author: Petr Simecek <Petr.Simecek@jax.org>, Brian S Yandell <byandell@wisc.edu>,
@@ -12,7 +12,7 @@ Imports:
     feather
 Suggests:
     testthat,
-    qtl2 (>= 0.8),
+    qtl2 (>= 0.15-1),
     knitr, rmarkdown
 VignetteBuilder: knitr
 License: GPL-3

--- a/tests/testthat/test-pull_genoprobpos.R
+++ b/tests/testthat/test-pull_genoprobpos.R
@@ -1,0 +1,25 @@
+context("pull_genoprobpos")
+
+test_that("qtl2::pull_genoprobpos works with qtl2feather", {
+
+    library(qtl2)
+    iron <- read_cross2(system.file("extdata", "iron.zip", package="qtl2"))
+    iron <- iron[,c(18,19,"X")]
+
+    map <- insert_pseudomarkers(iron$gmap, step=1)
+    probs <- calc_genoprob(iron, map, error_prob=0.002)
+
+    dir <- tempdir()
+    fprobs <- feather_genoprob(probs, "iron_probs", dir)
+
+    marker <- find_marker(map, 18, 30.4)
+    pr_18_30 <- pull_genoprobpos(probs, marker)
+    fpr_18_30 <- pull_genoprobpos(fprobs, marker)
+
+    expect_equal(pr_18_30, fpr_18_30)
+
+    # clean up
+    lf <- list.files(dir, pattern=".feather")
+    unlink(file.path(dir, lf))
+
+})


### PR DESCRIPTION
 - Add test of `pull_genoprobpos()` with qtl2feather

 - Also bump version, suggest qtl2 ver 0.15-1, and revise travis file
   to point to [kbroman/qtl2](https://github.com/kbroman/qtl2) (devel version) rather than [rqtl/qtl2](https://github.com/rqtl/qtl2)